### PR TITLE
Create parameter for dc flatten effort

### DIFF
--- a/steps/synopsys-dc-synthesis/configure.yaml
+++ b/steps/synopsys-dc-synthesis/configure.yaml
@@ -35,6 +35,7 @@ commands:
 parameters:
   clock_period: 1.0
   design_name: undefined
+  flatten_effort: 0
 
 #-------------------------------------------------------------------------
 # Debug

--- a/steps/synopsys-dc-synthesis/designer_interface.tcl
+++ b/steps/synopsys-dc-synthesis/designer_interface.tcl
@@ -19,6 +19,7 @@
 
 set dc_design_name              $::env(design_name)
 set dc_clock_period             $::env(clock_period)
+set dc_flatten_effort           $::env(flatten_effort)
 
 #-------------------------------------------------------------------------
 # Inputs

--- a/steps/synopsys-dc-synthesis/pre_synth.tcl
+++ b/steps/synopsys-dc-synthesis/pre_synth.tcl
@@ -40,7 +40,7 @@ set DC_GATE_CLOCK true
 # constants across the boundary, although this can be disabled with a
 # variable if we really wanted to disable it.
 
-set DC_FLATTEN_EFFORT 0
+set DC_FLATTEN_EFFORT $env(flatten_effort)
 
 # When boundary optimizations are off, set this variable to true to still
 # allow unconnected registers to be removed.


### PR DESCRIPTION
Make the flatten effort a parameter for the dc synthesis step to that we don't have to create a custom synthesis node to change the flattening effort.